### PR TITLE
Added 'end' event to decoder to indicate no more 'data' events.

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -21,9 +21,13 @@ MP3Decoder = Decoder.extend(function() {
             return this.once('available', this.readChunk);
         
         if (!frame.decode(stream)) {
-            if (stream.error !== MP3Stream.ERROR.BUFLEN && stream.error !== MP3Stream.ERROR.LOSTSYNC)
+            if (stream.error === MP3Stream.ERROR.BUFLEN){
+                this.emit('end');
+            }else if (stream.error !== MP3Stream.ERROR.LOSTSYNC)
                 this.emit('error', 'A decoding error occurred: ' + stream.error);
-                
+            }
+            //something should be done for LOSTSYNC, so listeners aren't left hanging,
+            //but I don't know what exactly
             return;
         }
         


### PR DESCRIPTION
The decoder now emits an 'end' event when it encounters a BUFLEN error, allowing listeners to be notified of when decoding has completed. I'm not sure if this is the best way to identify the end of a file, or what to do with LOSTSYNC, so consider this a feature request if there's an obviously better way to do it.
This corresponds with my 'end' event for Assets pull request on Aurora.js.
