### PR TITLE
Correctly set hlen in quad tables

### DIFF
--- a/src/huffman.js
+++ b/src/huffman.js
@@ -1,4 +1,3 @@
-
 /*
  * These are the Huffman code words for Layer III.
  * The data for these tables are derived from Table B.7 of ISO/IEC 11172-3.
@@ -23,7 +22,8 @@ var huffquad_V = function (v, w, x, y, hlen) {
             v: v,
             w: w,
             x: x,
-            y: y
+            y: y,
+            hlen: hlen
         }
     };
 };


### PR DESCRIPTION
Without this, cachesz gets set to NaN after the first iteration of the quad loop.
