### PR TITLE
Demuxer throw error fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mp3",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An MP3 decoder for Aurora.js",
   "peerDependencies": {
     "av": "~0.4.0"


### PR DESCRIPTION
Hi! I wanna hotfix demuxer error handling.

What happened: library called 'audio-decode' use package 'av', that uses this package for decoding mp3-files to buffer.

Usage of 'av' in 'audio-decode': https://github.com/audiojs/audio-decode/blob/master/index.js#L80=

As you can see, error handling looks good. Buuut, in runtime in some cases thrown error terminate node process (screenshot): 
<img width="769" alt="изображение" src="https://user-images.githubusercontent.com/8094908/170135955-f0f4dabf-7903-410c-a512-3c396cc04cfa.png">

I try to handle this by try-catch block inside my project, but this dont work (idk why):
<img width="587" alt="изображение" src="https://user-images.githubusercontent.com/8094908/170136210-8c34bc7e-abf1-415b-b7e9-2656b671fbb2.png">

So, when I added try-catch block inside 'mp3' package (as at this PR) problem got fixed. So, handled error message look like this:
<img width="329" alt="изображение" src="https://user-images.githubusercontent.com/8094908/170136501-7c27eaa4-bdcd-46b4-8856-8a5f0050af9f.png">
